### PR TITLE
moves min_polling_interval to a proper place in app config

### DIFF
--- a/group_vars/pulsarservers.yml
+++ b/group_vars/pulsarservers.yml
@@ -58,7 +58,6 @@ pulsar_yaml_config:
   tool_dependency_dir: "{{ pulsar_dependencies_dir }}"
   # The following are the settings for the pulsar server to contact the message queue with related timeouts etc.
   message_queue_url: "pyamqp://{{ rabbitmq_user }}:{{ rabbitmq_password }}@{{ rabbitmq_hostname }}:{{ rabbitmq_port }}/{{ rabbitmq_vhost }}?ssl=true"
-  min_polling_interval: 60
   amqp_publish_retry: True
   amqp_publish_retry_max_retries: 5
   amqp_publish_retry_interval_start: 10
@@ -71,6 +70,7 @@ pulsar_yaml_config:
   managers:
     _default_:
       type: queued_drmaa
+      min_polling_interval: 60
       preprocess_action_max_retries: 10
       preprocess_action_interval_start: 2
       preprocess_action_interval_step: 2


### PR DESCRIPTION
Turned out that min_polling_interval affects only the manager's configuration. The default polling interval of 0.5s causes performance issues on our PBS server. This needs to be deployed on all of our pulsars when not actively copying data or doing pre/post-processing.